### PR TITLE
chore: add type checking

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,4 +1,4 @@
-name: Run tests on PR
+name: PR
 
 on:
   pull_request:
@@ -22,7 +22,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
   lint:
-    name: Run linting
+    name: Lint
     needs: [install]
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: npm run typecheck
 
   test:
-    name: Run tests
+    name: Test
     needs: [install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -35,6 +35,20 @@ jobs:
       - name: Run linting
         run: npm run lint
 
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Download dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Run linting
+        run: npm run typecheck
+
   test:
     name: Run tests
     needs: [install]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,20 @@ jobs:
       - name: Run linting
         run: npm run lint
 
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Download dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Run linting
+        run: npm run typecheck
+
   changeset:
     name: Create Release Pull Request or Publish to NPM
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "release": "npm run build && npx changeset publish",
     "test": "FORCE_COLOR=1 turbo test",
     "changeset": "changeset",
-    "generate:package": "turbo gen package"
+    "generate:package": "turbo gen package",
+    "typecheck": "FORCE_COLOR=1 turbo typecheck"
   },
   "private": true,
   "dependencies": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -12,7 +12,8 @@
     "build": "tsup-node src/index.ts --format esm,cjs --dts",
     "dev": "tsc --watch --noEmit",
     "lint": "eslint \"src/**/*.ts*\"",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "vitest typecheck --passWithNoTests"
   },
   "devDependencies": {
     "tsconfig": "*"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -12,7 +12,8 @@
     "build": "tsup-node src/index.ts --format esm,cjs --dts",
     "dev": "tsc --watch --noEmit",
     "lint": "eslint \"src/**/*.ts*\"",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "vitest typecheck --passWithNoTests"
   },
   "devDependencies": {
     "tsconfig": "*"

--- a/packages/typed-router/package.json
+++ b/packages/typed-router/package.json
@@ -12,7 +12,8 @@
     "build": "tsup-node src/index.ts --format esm,cjs --dts",
     "dev": "tsc --watch --noEmit",
     "lint": "eslint \"src/**/*.ts*\"",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "vitest typecheck --passWithNoTests"
   },
   "devDependencies": {
     "express": "*",

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
       "cache": false
     },
     "lint": {},
-    "test": {}
+    "test": {},
+    "typecheck": {}
   }
 }

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -12,7 +12,8 @@
     "build": "tsup-node src/index.ts --format esm,cjs --dts",
     "dev": "tsc --watch --noEmit",
     "lint": "eslint \"src/**/*.ts*\"",
-    "test": "vitest --passWithNoTests"
+    "test": "vitest --passWithNoTests",
+    "typecheck": "vitest typecheck --passWithNoTests"
   },
   "devDependencies": {
     "tsconfig": "*"


### PR DESCRIPTION
Fixes #49

This PR adds type checking using Vitest's [type checking](https://vitest.dev/guide/testing-types.html). In our case, it basically only runs `tsc` for us. We can add _actual_ type tests, but I haven't been able to find a good use case for us, so I'm not implementing any tests for now. The type checking will also run as part of our release and PR workflows.